### PR TITLE
Knitr imports fix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', suffix: '', not_cran: 'true', vignettes: 'NULL'}
+          - {os: windows-latest, r: 'devel', suffix: '', not_cran: 'true', vignettes: 'NULL'}
           - {os: macOS-latest, r: 'release', suffix: '', not_cran: 'true', vignettes: 'NULL'}
-          - {os: macOS-latest, r: 'devel', suffix: '', not_cran: 'true', vignettes: 'NULL'}
           - {os: ubuntu-16.04, r: 'release', suffix: '', not_cran: 'true', vignettes: 'NULL', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     styler,
     codetools,
     highr,
+    evaluate,
     rstudioapi
 Suggests:
     testthat (>= 2.1.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
 Maintainer: Abhraneel Sarma <abhraneel@u.northwestern.edu>
 License: GPL (>= 3)
 Encoding: UTF-8
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.0.9000
 Depends:
     R (>= 3.5.0)
 Suggests:
@@ -39,6 +39,10 @@ Imports:
     magrittr,
     stringi,
     modelr,
+    formatR,
+    styler,
+    codetools,
+    highr,
     rstudioapi
 Language: en-US
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,19 +13,6 @@ Encoding: UTF-8
 RoxygenNote: 7.1.0.9000
 Depends:
     R (>= 3.5.0)
-Suggests:
-    testthat (>= 2.1.0),
-    lubridate,
-    rmarkdown,
-    covr,
-    broom,
-    boot,
-    gganimate,
-    gifski,
-    forcats,
-    stringr,
-    cowplot,
-    png
 Imports:
     dplyr (>= 0.8.1),
     ggplot2 (>= 3.0.0),
@@ -44,5 +31,18 @@ Imports:
     codetools,
     highr,
     rstudioapi
+Suggests:
+    testthat (>= 2.1.0),
+    lubridate,
+    rmarkdown,
+    covr,
+    broom,
+    boot,
+    gganimate,
+    gifski,
+    forcats,
+    stringr,
+    cowplot,
+    png
 Language: en-US
 VignetteBuilder: knitr


### PR DESCRIPTION
The PR closes #60, and closes #61 

Changes include:

- Adding some missing imports from knitr to Imports
- Reversing order of Imports and Suggests in DESCRIPTION
- Using a silly hack to suppress warnings against using `:::`. Basically I add <code>\`%:::%\` = \`...\`</code> to the top of any function that uses `:::` (because we can't guarantee the `%:::%` thing is visible in some cases, also as a reminder to fix those functions later). Then you can replace any instance of `package:::function(x,y)` with `('package'%:::%'function')(x,y)` inside that function and you won't get the warning :). 