### PR TITLE
Interactive rmd

### DIFF
--- a/R/block_exec.R
+++ b/R/block_exec.R
@@ -173,7 +173,7 @@ block_exec_R = function(options) {
           # keep only selected
           if (keep == 'index') res = res[-which(figs)[-keep.idx]]
           # merge low-level plotting changes
-          if (keep == 'high') res = merge_low_plot(res, figs)
+          if (keep == 'high') res = ('knitr'%:::%'merge_low_plot')(res, figs)
         }
       }
     }

--- a/R/engine_multiverse.R
+++ b/R/engine_multiverse.R
@@ -8,25 +8,26 @@ multiverse_engine <- function(options) {
 }
 
 multiverse_block_code <- function(.multiverse_name, .label, .code) {
-  if ( !(.multiverse_name %in% ls(envir = globalenv()))) {
-    stop("Cannot add code to multiverse object which has not been created")
+  if ( !(.multiverse_name %in% ls(envir = knit_global()))) {
+    stop(
+      "Multiverse object `", .multiverse_name, "` was not found.\n",
+      "You may need to execute `", .multiverse_name, " <- multiverse()` to create the multiverse\n",
+      "before executing a multiverse code block."
+    )
   }
   
   if (strsplit(.label, "-[0-9]+") == "unnamed-chunk") {
     stop("Please provide a label to your multiverse code block")
   }
   
-  .multiverse = get(.multiverse_name, envir = globalenv())
+  .multiverse = get(.multiverse_name, envir = knit_global())
   n <- length(.code)
   
   pasted <- paste(.code, collapse = "\n")
-  .expr <- parse(text = c("{", pasted, "}"))[[1]]
+  .expr <- parse(text = c("{", pasted, "}"), keep.source = FALSE)[[1]]
   .m = attr(.multiverse, "multiverse")
   
-  # within the call to `inside()` we detect whether the 
-  # execution is in interactive mode or during knit mode.
-  # If in knit mode, it auto-executes all the universes in the multiverse.
-  inside(.multiverse, !!.expr, .label)
+  add_and_parse_code(.multiverse, .expr, .label)
   
   if ( is.list(.m[['parameters']]) & length(.m[['parameters']]) == 0 ) {
     # executing everything in the default universe
@@ -43,20 +44,45 @@ multiverse_block_code <- function(.multiverse_name, .label, .code) {
 }
 
 multiverse_default_block_exec <- function(.code, options, knit = FALSE) {
+  # ugly hack to get around `:::` warnings (TODO: delete eventually)
+  `%:::%` = `:::`
+
   if (knit) {
     # when knitting we are not performing any traditional evaluation
     # hence we can not evaluate the code chunk using default evaluation
     options$eval = FALSE
     options$class.source = "multiverse"
+
+    options$engine = "R"
+    options$comment = ""
+    options$dev = 'png'
+    
+    block_exec_R(options)
+    
   } else {
-    options$code = .code
+    # when in interactive mode, execute the default analysis in the knitr global environment
+    
+    # first and last elements of `code` are "{" and "}" so we have to strip them.
+    # (otherwise only the last thing would be printed as the entire expression would
+    # only return one object)
+    code = .code[-c(1, length(.code))]
+    
+    # when not knitting (i.e. interactive mode) we just use evaluate()
+    # to evaluate the various pieces of code in the code chunk and return
+    # the output strings from each line of code.
+    outputs = evaluate::evaluate(
+      code, 
+      # must have new_device = FALSE otherwise plots don't seem to be written to
+      # the graphics device inside rmarkdown in RStudio
+      new_device = FALSE,
+      envir = knit_global()
+    )
+
+    # only output character vectors and conditions (warnings, etc) values (not plots or
+    # source code) here, as everything else (e.g. graphics, messages) will have already
+    # been output during evaluate()
+    outputs[sapply(outputs, function(x) is.character(x) || is_condition(x))]
   }
-  
-  options$engine = "R"
-  options$comment = ""
-  options$dev = 'png'
-  
-  block_exec_R(options)
 }
 
 knitr::knit_engines$set(multiverse = multiverse_engine)

--- a/R/execute.R
+++ b/R/execute.R
@@ -69,26 +69,27 @@ execute_default.default <- function(multiverse) {
 #' @rdname execute
 #' @export
 execute_default.multiverse <- function(multiverse) {
-  m_obj = attr(multiverse, "multiverse")
-  execute_universe(m_obj)
+  execute_universe(multiverse)
 }
 
 #' @rdname execute
 #' @export
 execute_universe <- function(multiverse, .universe = NULL) {
+  m_obj = attr(multiverse, "multiverse")
+  
   if(is.null(.universe)) {
-    .param_assgn = multiverse[['default_parameter_assignment']]
+    .param_assgn = m_obj[['default_parameter_assignment']]
   } else {
     .param_assgn = .universe
   }
   
-  if ( is.list(multiverse[['parameters']]) & length(multiverse[['parameters']]) == 0 ) {
-    .c = multiverse[['multiverse_table']][['.code']][[1]]
-    env = multiverse[['multiverse_table']][['.results']][[1]]
+  if ( is.list(m_obj[['parameters']]) & length(m_obj[['parameters']]) == 0 ) {
+    .c = m_obj[['multiverse_table']][['.code']][[1]]
+    env = m_obj[['multiverse_table']][['.results']][[1]]
   } else {
     stopifnot(is.numeric(.param_assgn) || !is.null(.param_assgn))
-    .c = multiverse[['multiverse_table']][['.code']][[.param_assgn]]
-    env = multiverse[['multiverse_table']][['.results']][[.param_assgn ]]
+    .c = m_obj[['multiverse_table']][['.code']][[.param_assgn]]
+    env = m_obj[['multiverse_table']][['.results']][[.param_assgn ]]
   }
   
   execute_code_from_universe(.c, env)

--- a/tests/testrmd/interactive.Rmd
+++ b/tests/testrmd/interactive.Rmd
@@ -1,0 +1,41 @@
+# Quick test for interactive rmarkdown
+
+```{r setup}
+library(tidyverse)
+library(multiverse)
+```
+
+## Introduction
+
+This document is used for testing interactive Rmd output manually in RStudio.
+
+```{r}
+M = multiverse()
+```
+
+## plots, errors, and messages
+
+```{multiverse plots, inside = M_block, fig.width = 5, fig.height = 2}
+hist(1:10)
+```
+
+```{multiverse ggplots, inside = M_block, fig.width = 5, fig.height = 2}
+data.frame(x = 1:10) %>%
+  ggplot(aes(x = x, y = x)) +
+  geom_point()
+```
+
+
+```{multiverse plots-errors-messages, inside = M_block, fig.width = 5, fig.height = 2}
+x = list()
+message("hi")
+
+data.frame(x = 1:10) %>%
+  ggplot(aes(x = x, y = x)) +
+  geom_point()
+
+hist(1:10)
+
+print("hello")
+x = x + 1   # should give an error
+```

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -40,7 +40,7 @@ test_that("`conditions()` throws error for objects of class other than multivers
 
 test_that("basic retrieval works with `multiverse()`", {
   M <- multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr({
+  add_and_parse_code(M, expr({
     df <- data.frame (x = 1:10 ) %>%
       mutate( y = branch( values_y, TRUE, FALSE )) %>%
       mutate(
@@ -50,7 +50,7 @@ test_that("basic retrieval works with `multiverse()`", {
                     "sum" ~ (x + y)
         )
       )
-  }), execute = FALSE)
+  }))
 
   m_tbl = expand(M) %>% select(-.parameter_assignment, -.code, -.results)
   m_tbl.ref = expand.grid(list(

--- a/tests/testthat/test-execute.R
+++ b/tests/testthat/test-execute.R
@@ -5,8 +5,8 @@ values_x = exprs("a", 0, 5, 10, 14)
 
 test_that("`execute_default` executes the default analysis in the multiverse", {
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"),
-                     expr({x <- branch(value_x, "a", 0, 5, 10, 14)}), execute = FALSE
+  add_and_parse_code(M,
+                     expr({x <- branch(value_x, "a", 0, 5, 10, 14)})
   )
   execute_default(M)
   expect_equal(M$x, "a")
@@ -14,8 +14,8 @@ test_that("`execute_default` executes the default analysis in the multiverse", {
 
 test_that("`execute_multiverse` executes the all the analyses in the multiverse", {
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"),
-                     expr({x <- branch(value_x, "a", 0, 5, 10, 14)}), execute = FALSE
+  add_and_parse_code(M,
+                     expr({x <- branch(value_x, "a", 0, 5, 10, 14)})
   )
   execute_multiverse(M)
   expect_equal(from_universe_i(M, 1, x), values_x[[1]])

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -172,10 +172,10 @@ test_that("syntax tree without branches is correctly returned", {
 
   M.no_branch = multiverse()
 
-  add_and_parse_code(attr(M.no_branch, "multiverse"), attr(M.no_branch, "multiverse_super_env"), quote({
+  add_and_parse_code(M.no_branch, quote({
     df <- test_df %>%
       mutate( ComputedCycleLength = StartDateofLastPeriod - StartDateofPeriodBeforeLast )
-  }), execute = FALSE)
+  }))
 
   expect_equal(code(M.no_branch), list(an_expr))
 })

--- a/tests/testthat/test-inside.R
+++ b/tests/testthat/test-inside.R
@@ -71,8 +71,8 @@ test_that("`add_and_parse_code` stores code as a list of `language`", {
   })
 
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr.1)
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr.2)
+  add_and_parse_code(M, expr.1)
+  add_and_parse_code(M, expr.2)
 
   expect_true( is.list(code(M)) )
   expect_true( all(map_lgl(code(M), is.language)) )
@@ -85,22 +85,27 @@ test_that("`add_and_parse_code` parses the code", {
   })
 
   M = multiverse()
-  M.R6 = attr(M, "multiverse")
-  add_and_parse_code(M.R6, attr(M, "multiverse_super_env"), an_expr)
+  add_and_parse_code(M, an_expr)
 
+  M.R6 = attr(M, "multiverse")
   expect_equal( dim(M.R6$multiverse_table), c(4, 5) )
   expect_equal( length(M.R6$parameters), 1 )
   expect_equal( length(M.R6$parameters$value_y), 4 )
+  expect_equal( M.R6$multiverse_table$.universe, 1:4 )
+  expect_equal( M.R6$multiverse_table$value_y, c("0", "3", "x + 1", "x^2") )
+  expect_equal( M.R6$multiverse_table$.parameter_assignment, 
+    lapply(c("0", "3", "x + 1", "x^2"), function(x) list(value_y = x))
+  )
 })
 
-test_that("`add_and_parse_code` executes the default analysis", {
+test_that("`inside` executes the default analysis", {
   an_expr = expr({
     x = data.frame(x = 1:10) %>%
       mutate( y = branch( value_y, 0, 3, x + 1, x^2))
   })
 
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), an_expr)
+  inside(M, !!an_expr)
 
   df = attr(M, "multiverse")$multiverse_table$.results[[1]]$x
   df.ref =  data.frame(x = 1:10) %>%  mutate( y = 0 )
@@ -111,11 +116,11 @@ test_that("`add_and_parse_code` executes the default analysis", {
 test_that("continuous parameters defined in the multiverse are evaluated", {
   .expr_1 = expr({
     y <- branch(foo, "option1" ~ 1, .options = 2:10)
-  }) %>% eval_seq_in_code()
+  }) %>% expand_branch_options()
 
   .expr_2 = expr({
     y <- branch(foo, "option1" ~ 1, .options = seq(2, 3, by = 0.1))
-  }) %>% eval_seq_in_code()
+  }) %>% expand_branch_options()
 
   .ref_expr_1 = expr({
     y <- branch(foo, "option1" ~ 1, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)
@@ -131,7 +136,7 @@ test_that("continuous parameters defined in the multiverse are evaluated", {
 })
 
 
-test_that("`add_and_parse_code` executes the default analysis", {
+test_that("`inside` executes the default analysis", {
   M = multiverse()
   df <- data.frame(x = 1:10) %>% mutate( y = x^2 + sample(10:20, 10))
   

--- a/tests/testthat/test-parse_multiverse.R
+++ b/tests/testthat/test-parse_multiverse.R
@@ -289,7 +289,7 @@ test_that("`get_condition` ignores `%when%` if assigned to subexpression of an o
 
 test_that("`parse_multiverse` returns the complete parameter table", {
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr({
+  add_and_parse_code(M, expr({
     df <- test_df  %>%
       mutate( ComputedCycleLength = StartDateofLastPeriod - StartDateofPeriodBeforeLast ) %>%
       mutate( NextMenstrualOnset = branch(menstrual_calculation,
@@ -311,7 +311,7 @@ test_that("`parse_multiverse` returns the complete parameter table", {
           "cer_option1" ~ TRUE,
           "cer_option2" ~ Sure1 > 6 | Sure2 > 6
       ))
-  }), execute = FALSE)
+  }))
 
   p_tbl_df = expand(M) %>% select(-.code, -.results)
 
@@ -337,12 +337,12 @@ test_that("`parse_multiverse` returns the complete parameter table", {
 test_that("`parse_multiverse` creates an empty data.frame for the 'multiverse_tbl' slot when it is passed an expression without any branches", {
   p_tbl_df.ref = tibble::tibble(
     .parameter_assignment = list( list() ),
-    .code = list( list(rlang::expr( df <- data.frame(x = 1:10) )) )
+    .code = list( list(rlang::expr( {df <- data.frame(x = 1:10)} )) )
   )
 
   M = multiverse()
   # this should NOT generate a warning
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr( df <- data.frame(x = 1:10) ), execute = FALSE)
+  add_and_parse_code(M, expr( df <- data.frame(x = 1:10) ))
   p_tbl_df = expand(M) %>% select(-.results)
 
   expect_equal( as.list(p_tbl_df), as.list(p_tbl_df.ref) )
@@ -360,7 +360,7 @@ test_that("`parse_multiverse` works when conditions are specified", {
   filter( values_z != "sum" | values_y == TRUE )
 
   M <- multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr({
+  add_and_parse_code(M, expr({
     df <- data.frame (x = 1:10 ) %>%
       mutate( y = branch( values_y,
                           TRUE,
@@ -373,7 +373,7 @@ test_that("`parse_multiverse` works when conditions are specified", {
                     "sum" ~ (x + y) %when% (values_y == TRUE)
         )
       )
-  }), execute = FALSE)
+  }))
 
   p_tbl_df = expand(M) %>% select( -.parameter_assignment, -.code, -.results )
   expect_equal( as.list(p_tbl_df), as.list(p_tbl_df.ref) )
@@ -381,7 +381,7 @@ test_that("`parse_multiverse` works when conditions are specified", {
 
 test_that("`parse_multiverse` requires multiple uses of the same paramater to cover all options", {
   M = multiverse()
-  expect_error(add_and_parse_code(attr(M, "multiverse"), execute = FALSE, expr({
+  expect_error(add_and_parse_code(M, expr({
     some_var = branch(parameter,
       "option1" ~ expr1,
       "option2" ~ expr2
@@ -399,7 +399,7 @@ test_that("`parameter_assignment` is created appropriately for single parameter 
   ref_list = lapply(c("mc_option1", "mc_option2", "mc_option3"), function(x) list(menstrual_calculation = x))
 
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr({
+  add_and_parse_code(M, expr({
     df <- test_df %>%
       mutate( ComputedCycleLength = StartDateofLastPeriod - StartDateofPeriodBeforeLast ) %>%
       mutate( NextMenstrualOnset = branch(menstrual_calculation,
@@ -407,7 +407,7 @@ test_that("`parameter_assignment` is created appropriately for single parameter 
                                           "mc_option2" ~ StartDateofLastPeriod + ReportedCycleLength,
                                           "mc_option3" ~ StartDateNext)
       )
-  }), execute = FALSE)
+  }))
 
   m.tbl = expand(M)
 
@@ -416,7 +416,7 @@ test_that("`parameter_assignment` is created appropriately for single parameter 
 
 test_that("`parameter_assignment` is created appropriately for two or more parameter multiverses", {
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr({
+  add_and_parse_code(M, expr({
     df <- test_df %>%
       mutate( ComputedCycleLength = StartDateofLastPeriod - StartDateofPeriodBeforeLast ) %>%
       mutate( NextMenstrualOnset = branch(menstrual_calculation,
@@ -424,7 +424,7 @@ test_that("`parameter_assignment` is created appropriately for two or more param
                                           "mc_option2" ~ StartDateofLastPeriod + ReportedCycleLength,
                                           "mc_option3" ~ StartDateNext)
       ) %>%  filter( branch(certainty, "cer_option1" ~ TRUE, "cer_option2" ~ Sure1 > 6 | Sure2 > 6 ))
-  }), execute = FALSE)
+  }))
 
   m.list = expand(M)$.parameter_assignment
 
@@ -468,7 +468,7 @@ test_that("unnamed options in branches are supported", {
 
 test_that("conditions are extracted when specified using `branch_assert`", {
   M = multiverse()
-  add_and_parse_code(attr(M, "multiverse"), attr(M, "multiverse_super_env"), expr({
+  add_and_parse_code(M, expr({
     df <- test_df  %>%
       mutate( ComputedCycleLength = StartDateofLastPeriod - StartDateofPeriodBeforeLast ) %>%
       mutate(NextMenstrualOnset = branch(menstrual_calculation,
@@ -503,7 +503,7 @@ test_that("conditions are extracted when specified using `branch_assert`", {
       branch_assert(cycle_length != "cl_option2" | menstrual_calculation == "mc_option2") %>%
       branch_assert(relationship_status != "rs_option3" | menstrual_calculation == "mc_option1") %>%
       branch_assert(fertile != "fer_option4" | certainty == "cer_option2")
-  }), execute = FALSE)
+  }))
 
   cond.ref = list(
     expr(cycle_length != "cl_option2" | menstrual_calculation == "mc_option2"),


### PR DESCRIPTION
This should fix interactive rmds. It also does a few other things:

- removes execution logic from add_and_parse_code (so that it really just does what its name says). It also makes it so that no internal code ever calls inside(), which I think should be a user-facing function only. Internal code that wants to add stuff to the multiverse should call `add_and_parse_code()` directly. Then if it wants to execute something, it can do so afterwards. One upshot of this is that I think the execution of all multiverses when knitting will not happen anymore --- but I assumed you (@abhsarma) were changing that anyway so I didn't try to fix that (it was broken on this branch anyway).

- renames eval_seq_in_code to expand_branch_options as that seemed to be what it was doing

- moved the use of eval_seq_in_code (now expand_branch_options) to be inside add_and_parse_code, and also moved the check that the code is contained in "{" there. This makes `add_and_parse_code` the single canonical internal function for the various checks and whatnot needed to add code to the multiverse.

- simplified the add_and_parse_code signature to take S3 multiverse objects.

- makes execute_universe take S3 multiverse objects.

- adds a test rmd (in tests/testrmd) that can be executed interactively to test interactive rmarkdown functionality. I don't know how to set up these tests in an automated way so that seemed the simplest approach.