### PR TITLE
Return both tryStack and the side-effected environment.

### DIFF
--- a/R/execute.R
+++ b/R/execute.R
@@ -86,14 +86,18 @@ exec_all <- function(x, cores, progress, step, steps) {
   
   mcmapply_fn <- if (progress) {pbmcapply::pbmcmapply} else {mcmapply}
   
-  .res <- mcmapply_fn(execute_code_from_universe, .code_list, .env_list, mc.cores = cores)
+  .res <- mcmapply_fn(execute_code_from_universe, .code_list, .env_list, mc.cores = cores, SIMPLIFY = F)
   
-  lapply(seq_along(.res), function(i, x) {
+  mapply(function(old_env, r) {list2env(as.list(r$env), envir = old_env)}, .env_list, .res)
+  
+  .ts <- lapply(.res, function(r) {r$ts})
+  
+  lapply(seq_along(.ts), function(i, x) {
     if (is(x[[i]], "try-error"))  {
       warning("error in universe ", i, "\n")
        cat(x[[i]])
     }
-  }, x = .res)
+  }, x = .ts)
 }
 
 
@@ -112,8 +116,8 @@ execute_universe <- function(multiverse, .universe = 1) {
 }
 
 execute_code_from_universe <- function(.c, .env = globalenv()) {
-  # lapply(.c, eval, envir = .env)
-  tryStack(lapply(.c, eval, envir = .env), silent = TRUE)
+  ts <- tryStack(lapply(.c, eval, envir = .env), silent = TRUE)
+  list(ts = ts, env = .env)
 }
 
 # for a universe, get the indices which need to be executed


### PR DESCRIPTION
I think your appraisal of the problem was correct in that it's not executing in the right environments. That helped me narrow down the problem, and I think I have a fix. In short, instead of `execute_code_from_universe` only returning whether there were errors, it returns a list containing both the tryStack result and the updated environment. Then, `exec_all` takes the resulting environment and updates all the entries in the original environment.

This works for my workflow of exactly one multiverse code chunk, but I don't know enough about the rest of the library to know if it's breaking something else. Also I couldn't really tell what naming convention you had going, so I tried to do my best.

Even if the switch eventually happens to futures, I think this fix will still be valuable - I think I agree with you that this would have been a trouble in any multicore / multisession libraries.

Here's the output of the reprex I gave in #107:

``` r
library(tidyverse)
devtools::load_all("~/thesis/multiverse")
#> ℹ Loading multiverse
#> Loading required package: knitr

M_cores_1 <- multiverse()

inside(M_cores_1, {
  variable_inside_env <- 2 * branch(
    var_num,
    "var1" ~ 1,
    "var2" ~ 2,
    "var3" ~ 3
  )
})

execute_multiverse(M_cores_1, cores = 1)

multiverse_results_1 <- expand(M_cores_1) %>%
  mutate(
    environment_variables = map_dbl(.results, ~length(ls(envir = .x))),
    environment_names = map_chr(.results, ~paste0(ls(envir = .x), collapse = ", ")),
    variable_inside_env = map_dbl(.results, "variable_inside_env")
  ) %>%
  select(-.parameter_assignment, -.code)

print(multiverse_results_1)
#> # A tibble: 3 × 6
#>   .universe var_num .results environment_vari… environment_nam… variable_inside…
#>       <int> <chr>   <list>               <dbl> <chr>                       <dbl>
#> 1         1 var1    <env>                    1 variable_inside…                2
#> 2         2 var2    <env>                    1 variable_inside…                4
#> 3         3 var3    <env>                    1 variable_inside…                6

# Multiple cores

M_cores_2 <- multiverse()

inside(M_cores_2, {
  variable_inside_env <- 2 * branch(
    var_num,
    "var1" ~ 1,
    "var2" ~ 2,
    "var3" ~ 3
  )
})

execute_multiverse(M_cores_2, cores = 2)

multiverse_results_2 <- expand(M_cores_2) %>%
  mutate(
    environment_variables = map_dbl(.results, ~length(ls(envir = .x))),
    environment_names = map_chr(.results, ~paste0(ls(envir = .x), collapse = ", ")),
    variable_inside_env = map_dbl(.results, "variable_inside_env")
  ) %>%
  select(-.parameter_assignment, -.code)

print(multiverse_results_2)
#> # A tibble: 3 × 6
#>   .universe var_num .results environment_vari… environment_nam… variable_inside…
#>       <int> <chr>   <list>               <dbl> <chr>                       <dbl>
#> 1         1 var1    <env>                    1 variable_inside…                2
#> 2         2 var2    <env>                    1 variable_inside…                4
#> 3         3 var3    <env>                    1 variable_inside…                6
```

<sup>Created on 2022-04-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
