### PR TITLE
Universe execution

### DIFF
--- a/R/execute.R
+++ b/R/execute.R
@@ -155,7 +155,7 @@ get_exec_order <- function(.m_diction, .uni, .level) {
     .p <- .m_diction$get(.m_diction$keys()[[.level]])[[.uni]]$parent
     c(get_exec_order(.m_diction, .p, .level - 1), .uni)
   } else {
-    1
+    .uni
   }
 }
 

--- a/R/inside.R
+++ b/R/inside.R
@@ -33,6 +33,8 @@
 #' @param .label It is extracted automatically from the code block of type \code{multiverse}
 #' when run in an RMarkdown document. This should be used only within an RMarkdown document. 
 #' Defaults to NULL.
+#' 
+#' @param .execute_default Should the default multiverse be executed as part of this call?
 #'
 #' @return a multiverse object
 #'

--- a/R/inside.R
+++ b/R/inside.R
@@ -92,7 +92,7 @@
 #'
 #' @name inside
 #' @export
-inside <- function(multiverse, .expr, .label = NULL) {
+inside <- function(multiverse, .expr, .label = NULL, .execute_default = T) {
   .code = enexpr(.expr)
   
   add_and_parse_code(multiverse, .code, .label)
@@ -101,7 +101,9 @@ inside <- function(multiverse, .expr, .label = NULL) {
   
   # direct calls to inside() by the user result in execution of the
   # default universe in the global environment.
-  execute_universe(multiverse)
+  if (.execute_default) {
+    execute_universe(multiverse)
+  }
 }
 
 add_and_parse_code <- function(multiverse, .expr, .name = NULL) {

--- a/man/inside.Rd
+++ b/man/inside.Rd
@@ -4,7 +4,7 @@
 \alias{inside}
 \title{Pass code into the multiverse}
 \usage{
-inside(multiverse, .expr, .label = NULL)
+inside(multiverse, .expr, .label = NULL, .execute_default = T)
 }
 \arguments{
 \item{multiverse}{A multiverse object. A multiverse object is an S3 object which can be defined using \code{multiverse()}}
@@ -15,6 +15,8 @@ Since it accepts a single argument, chunks of code can be passed using `\{\}`. S
 \item{.label}{It is extracted automatically from the code block of type \code{multiverse}
 when run in an RMarkdown document. This should be used only within an RMarkdown document. 
 Defaults to NULL.}
+
+\item{.execute_default}{Should the default multiverse be executed as part of this call?}
 }
 \value{
 a multiverse object

--- a/tests/testthat/test-execute.R
+++ b/tests/testthat/test-execute.R
@@ -142,6 +142,20 @@ test_that("`execute_universe` sends message about error but does not stop execut
   expect_equal( env_get(expand(M2)$.results[[5]], "x"), 14 )
 })
 
+test_that("`execute_universe` executes the correct universe", {
+  M <- multiverse()
+  an_expr <- expr({
+    x <- branch(value_x, 1, 2, 3, 4)
+  })
+  
+  inside(M, !!an_expr)
+  
+  execute_universe(M, .universe = 3)
+  expect_true(env_has(expand(M)$.results[[3]], "x"))
+  expect_equal(env_get(expand(M)$.results[[3]], "x"), 3)
+  expect_false(env_has(expand(M)$.results[[2]], "x"))
+})
+
 test_that("multiverse sends warning message and continues to execute when warnings are encountered", {
   M <- multiverse()
   

--- a/tests/testthat/test-inside.R
+++ b/tests/testthat/test-inside.R
@@ -98,7 +98,7 @@ test_that("`add_and_parse_code` parses the code", {
   )
 })
 
-test_that("`inside` executes the default analysis", {
+test_that("`inside` executes the default analysis by default", {
   an_expr = expr({
     x = data.frame(x = 1:10) %>%
       mutate( y = branch( value_y, 0, 3, x + 1, x^2))
@@ -111,6 +111,17 @@ test_that("`inside` executes the default analysis", {
   df.ref =  data.frame(x = 1:10) %>%  mutate( y = 0 )
 
   expect_equal( as.list(df), as.list(df.ref) )
+})
+
+test_that("`inside` does not execute the default analysis when specified as such", {
+  an_expr = expr({
+    x = data.frame(x = 1:10) %>%
+      mutate( y = branch( value_y, 0, 3, x + 1, x^2))
+  })
+  
+  M = multiverse()
+  inside(M, !!an_expr, .execute_default = F)
+  expect_error(M$x, "object 'x' not found")
 })
 
 test_that("`expand_branch_options()`: continuous parameters defined in the multiverse are evaluated", {


### PR DESCRIPTION
I've run into one problem and one new option that I've needed to fix for my own use case. In the first, it appeared that the `.universe` argument to `execute_universe` did not run the specified universe. Second, I wanted an option to disable the execution of the default multiverse. These are in separate commits so feel free to pick and choose if you only want to include one.